### PR TITLE
Update products data install path in firestore DB and Add image and description to product popup

### DIFF
--- a/lib/productpopupscreen.dart
+++ b/lib/productpopupscreen.dart
@@ -6,7 +6,8 @@ import 'package:flutter/material.dart';
 class ProductPopupScreen extends StatefulWidget {
   final image;
   final product;
-  const ProductPopupScreen({super.key, required this.image, required this.product});
+  final description;
+  const ProductPopupScreen({super.key, required this.image, required this.product, required this.description});
 
   @override
   State<ProductPopupScreen> createState() => _ProductPopupScreenState();
@@ -32,7 +33,8 @@ class _ProductPopupScreenState extends State<ProductPopupScreen> {
                 Container(
                   height: 140,
                   child: Image.asset(
-                      "images/${widget.image}.jpg"
+                      //widget.image.toString()
+                      "images/image1.jpg"
                   ),
                 ),
                 Container(
@@ -56,7 +58,8 @@ class _ProductPopupScreenState extends State<ProductPopupScreen> {
             child: Container(
                   child: Container(
                           child: Text(
-                            "ブルーマウンテンは、ジャマイカにあるブルーマウンテン山脈の標高800から1,200 mの限られた地域で栽培されるコーヒー豆のブランドである",
+                            //"ブルーマウンテンは、ジャマイカにあるブルーマウンテン山脈の標高800から1,200 mの限られた地域で栽培されるコーヒー豆のブランドである",
+                            widget.description.toString(),
                             style: TextStyle(
                               color: Colors.black,
                               fontSize: 20,

--- a/lib/productpopupscreen.dart
+++ b/lib/productpopupscreen.dart
@@ -58,7 +58,6 @@ class _ProductPopupScreenState extends State<ProductPopupScreen> {
             child: Container(
                   child: Container(
                           child: Text(
-                            //"ブルーマウンテンは、ジャマイカにあるブルーマウンテン山脈の標高800から1,200 mの限られた地域で栽培されるコーヒー豆のブランドである",
                             widget.description.toString(),
                             style: TextStyle(
                               color: Colors.black,

--- a/lib/productselectionscreen.dart
+++ b/lib/productselectionscreen.dart
@@ -22,8 +22,6 @@ class _ProductSelectionScreenState extends State<ProductSelectionScreen> {
           .doc('javanican')
           .collection('products')
           .doc('beans')
-          .collection('categories')
-          .doc('blend_coffee')
           .get();
       return snapshot.data() as Map<String, dynamic>;
     }
@@ -72,7 +70,7 @@ class _ProductSelectionScreenState extends State<ProductSelectionScreen> {
                       itemBuilder: (context, index) {
                         final beanEntry = beanList[index];
                         final bean = beanEntry.value;
-                        return products("image8", bean['name'], bean['price'], 100);
+                        return products(bean['image'], bean['name'], bean['price'], bean['description']);
                       }
                   );
                 }
@@ -81,7 +79,7 @@ class _ProductSelectionScreenState extends State<ProductSelectionScreen> {
     );
   }
 
-  Widget products(image, name, price, gram){
+  Widget products(image, name, price, description){
     const containerHeight = 180.0;
     const containerWidth = 180.0;
     return Container(
@@ -93,7 +91,7 @@ class _ProductSelectionScreenState extends State<ProductSelectionScreen> {
             pieces = await Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => ProductPopupScreen(image: image, product: name.toString()),
+                  builder: (context) => ProductPopupScreen(image: image, product: name.toString(), description: description.toString()),
                 )
             );
             (widget.cart).add({'id':widget.id, 'name':name.toString(), 'pieces':pieces.toString(), 'price':price.toString()});
@@ -107,7 +105,8 @@ class _ProductSelectionScreenState extends State<ProductSelectionScreen> {
               child:
               Container(
                 child: Image.asset(
-                  "images/${image}.jpg",
+                  //image.toString(),
+                  "images/image1.jpg",
                   fit: BoxFit.cover,
                 ),
               ),
@@ -140,7 +139,7 @@ class _ProductSelectionScreenState extends State<ProductSelectionScreen> {
                     Container(
 
                       child: Text(
-                        " (${gram}g)",
+                        " (100g)",
                         style: TextStyle(
                             fontSize: 20
                         ),


### PR DESCRIPTION
以下のことを行った．
1. 製品リスト取得パスを Firestore DB に合わせて更新
2. 製品の個数を指定する画面において，各製品に合わせた説明を表示
また，各製品の画像について，現状では固定の画像を表示しているが，各製品に応じたものに変更できるようなコードをコメントアウトし，固定画像を表示しているコード部分においている．